### PR TITLE
Extended SocketsHandler to transfer messages between users in the same room  #43

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/sockets/SocketsHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/sockets/SocketsHandler.java
@@ -9,44 +9,112 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 
-
 public class SocketsHandler extends TextWebSocketHandler {
     private final UserRepository userRepository;
+    private final SessionManager sessionManager;
 
-    public SocketsHandler(UserRepository userRepository) {
+
+    public SocketsHandler(UserRepository userRepository, SessionManager sessionManager) {
         this.userRepository = userRepository;
+        this.sessionManager = sessionManager;
     }
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-       String query = session.getUri().getQuery();//get query param, separate check to avoid null pointer
+        var urlParameter = org.springframework.web.util.UriComponentsBuilder //use spring tool to parse url (no split necessary)
+                .fromUri(session.getUri())
+                .build()
+                .getQueryParams();
 
-       String token = null;
-       if(query != null && query.contains("token=")) {
-           token = query.split("token=")[1];
-       }
+        String token = urlParameter.getFirst("token");
+        String roomId = urlParameter.getFirst("roomId");
 
-       if(token == null | userRepository.findByToken(token) == null) {
-           session.close(CloseStatus.POLICY_VIOLATION);//close session before first message is sent if user is not authenticated
-           return;
-       }
-       session.sendMessage(new TextMessage("connected to" + session.getLocalAddress()));
+        if (token == null || roomId == null) {
+            session.close(CloseStatus.POLICY_VIOLATION);
+            return;
+        }
 
+        User user = userRepository.findByToken(token); //verify user
+        if (user == null) {
+            session.close(CloseStatus.POLICY_VIOLATION);
+            return;
+        }
+
+        try { //join
+            Long roomnumber = Long.parseLong(roomId);
+            Session raum = sessionManager.createRoom(roomnumber);
+            raum.addParticipant(user.getId(), session);
+
+            session.sendMessage(new TextMessage("connected"));
+        }
+        catch (NumberFormatException exception) {
+            session.close(CloseStatus.POLICY_VIOLATION);
+        }
     }
+
     @Override
     public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        String msg = message.getPayload();
-        System.out.println("Received message: " + msg);
-        System.out.println("From: " + session.getRemoteAddress());
+        Session raum = sessionManager.findRoomByConnection(session);
+        if (raum == null) {
+            return;
+        }
+
+        var urlParameter = org.springframework.web.util.UriComponentsBuilder //same as in line 24
+                .fromUri(session.getUri())
+                .build()
+                .getQueryParams();
+
+
+        String token = urlParameter.getFirst("token");
+
+        if (token == null) {
+            return;
+        }
+
+        User sender = userRepository.findByToken(token);
+
+        if (sender == null) {
+            return;
+        }
+
+        WebSocketSession partnerSession = raum.getPeerSocket(sender.getId()).orElse(null);
+        if (partnerSession != null) {
+            if (partnerSession.isOpen()) {
+                partnerSession.sendMessage(message);
+            }
+        }
     }
+
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
         System.out.println("Transport error: " + exception.getMessage());
         session.close(CloseStatus.SERVER_ERROR);
     }
+
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        System.out.println("Connection closed: " + session.getRemoteAddress() + " with status " + status);
-        System.out.println("CloseStatus: " + status);
+        Session raum = sessionManager.findRoomByConnection(session);
+
+        if (raum == null) {
+            return;
+        }
+
+        var urlParameter = org.springframework.web.util.UriComponentsBuilder //same as line 23
+                .fromUri(session.getUri())
+                .build()
+                .getQueryParams();
+
+        String token = urlParameter.getFirst("token");
+
+        if (token == null) {
+            return;
+        }
+        User user = userRepository.findByToken(token);
+
+        if (user == null) {
+            return;
+        }
+        raum.removeParticipant(user.getId());
+        sessionManager.removeEmptyRoom(raum.getRoomId());
     }
 }


### PR DESCRIPTION
- Extend afterConnectionEstablished to parse token and roomId from URL     
- Validate token and user before allowing connection to proceed
- Add participant to the correct room session -transfer incoming messages to the other participant
- remove participant from session on disconnect
- Remove empty rooms from memory after last participant leaves    #43