### PR TITLE
bugfix: use .equals() for Long comparison in joinRoom + test for IDs …

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/room/RoomController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/room/RoomController.java
@@ -79,17 +79,18 @@ public class RoomController {
             UserRepository.save(userToken);
             return room;
         }
-        if(room.getRoomStatus().equals(RoomStatus.JOINABLE)){
-            room.setRoomStatus(RoomStatus.FULL);
-            if(userToken.getId() == room.getCallerID()){
+        if (room.getRoomStatus().equals(RoomStatus.JOINABLE)) {
+            if (userToken.getId().equals(room.getCallerID())) {
                 throw new ResponseStatusException(HttpStatus.CONFLICT, "User cannot be caller and callee");
             }
+            room.setRoomStatus(RoomStatus.FULL);
             room.setCalleeID(userToken.getId());
             room.setCalleeLastHeartbeat(java.time.LocalDateTime.now());
             userToken.setRoomId(room.getId());
             UserRepository.save(userToken);
             return room;
         }
+
         if(room.getRoomStatus().equals(RoomStatus.FULL)){
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Room is Full");
         }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomControllerTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -143,6 +145,27 @@ public class RoomControllerTest {
 
         mockMvc.perform(getRequest).andExpect(status().isConflict());
 
+    }
+
+    @Test
+    public void Room_when_join_cannotBeCallerCallee_withLargeId() throws Exception {
+        User bigIdUser = new User();
+        bigIdUser.setId(200L);
+        bigIdUser.setToken("big");
+        given(userRepository.findByToken("big")).willReturn(bigIdUser);
+        given(roomService.getRoomById("1")).willReturn(rooms.get("1"));
+        Room room = rooms.get("1");
+        room.setRoomStatus(RoomStatus.JOINABLE);
+        room.setCallerID(200L);
+
+        MockHttpServletRequestBuilder getRequest = put("/rooms/1/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("token", "big");
+
+        mockMvc.perform(getRequest).andExpect(status().isConflict());
+
+        assertEquals(RoomStatus.JOINABLE, room.getRoomStatus());
+        assertNull(room.getCalleeID());
     }
 
     @Test


### PR DESCRIPTION
…> 127